### PR TITLE
Bumped Go to 1.18; [BREAKING CHANGE (most likely)] renamed `ParseHTML…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Cache Go modules
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Cache Go modules
       uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v0.56.0
 
 - Bumped Go to 1.18;
-- [BREAKING CHANGE (most likely)] renamed `ParseHTML`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively;
+- BREAKING: renamed `ParseHTML`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively;
+- BREAKING: renamed `extension.Result` to `extension.ExtResult`;
 - Made public `ParseHTML` & `ParseMD` just for the parsing purposes.
 
 ## v0.55.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - BREAKING: renamed `ParseHTML`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively;
 - BREAKING: renamed `extension.Result` to `extension.ExtResult`;
 - New option `AllTagWeights` for enabling parsing through everything;
+- New option `ExcludeTagsString` for prohibitting some of the tags;
 - Made public `ParseHTML` & `ParseMD` just for the parsing purposes.
 
 ## v0.55.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - BREAKING: renamed `extension.Result` to `extension.ExtResult`;
 - New option `AllTagWeights` for enabling parsing through everything;
 - New option `ExcludeTagsString` for prohibitting some of the tags;
-- Made public `ParseHTML` & `ParseMD` just for the parsing purposes.
+- `ParseHTML` & `ParseMD` are made public to open up parsing capabilities.
 
 ## v0.55.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.56.0
+
+- Bumped Go to 1.18;
+- [BREAKING CHANGE (most likely)] renamed `ParseHTML`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively;
+- Made public `ParseHTML` & `ParseMD` just for the parsing purposes.
+
 ## v0.55.0
 
 - improved handling of the words with the "`" or "'" symbols.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bumped Go to 1.18;
 - BREAKING: renamed `ParseHTML`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively;
 - BREAKING: renamed `extension.Result` to `extension.ExtResult`;
+- New option `AllTagWeights` for enabling parsing through everything;
 - Made public `ParseHTML` & `ParseMD` just for the parsing purposes.
 
 ## v0.55.0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: deps clean build
 
+TAG=0.56.0
+
 deps:
 	go get -u ./...
 
@@ -18,3 +20,6 @@ run:
 profile:
 	./_dist/tagify_darwin -s=https://zoomio.org/blog/post/mock_server-5632006343884800 -cpuprofile=_dist/tagify_darwin.prof
 	go tool pprof _dist/tagify_darwin _dist/tagify_darwin.prof
+
+tag:
+	./_bin/tag.sh ${TAG}

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ source html plain supports tags
 
 In a code (see [cmd/cli/cli.go](https://raw.githubusercontent.com/zoomio/tagify/master/cmd/cli/cli.go)).
 
-Use `-no-stop` flag to disable filtering out of the [stop-words](https://github.com/zoomio/stopwords/blob/master/stopwords.go).
+Use `-no-stop` flag to disable filtering out of the [stop-words](https://github.com/zoomio/stopwords).
 
 ## Installation
 
 ### Binary
 
-Get the latest [release](https://github.com/zoomio/tagify/releases/latest) of the Tagify by running this command in your shell:
+Get the latest [release](https://github.com/zoomio/tagify/releases/latest) by running this command in your shell:
 
 For MacOS:
 ```bash

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	AllTagWeights bool
 	TagWeights
 	ExtraTagWeights TagWeights
+	ExcludeTags     TagWeights
 	AdjustScores    bool
 	Extensions      []extension.Extension
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/zoomio/stopwords"
 
 	"github.com/zoomio/tagify/extension"

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/zoomio/stopwords"
 
 	"github.com/zoomio/tagify/extension"

--- a/config/config.go
+++ b/config/config.go
@@ -40,13 +40,15 @@ type Config struct {
 	Query   string
 	Content string
 	ContentType
-	Limit       int
-	Verbose     bool
-	NoStopWords bool
-	Lang        string
-	StopWords   *stopwords.Register
-	ContentOnly bool
-	FullSite    bool
+	Limit         int
+	Verbose       bool
+	NoStopWords   bool
+	SkipLang      bool
+	Lang          string
+	StopWords     *stopwords.Register
+	ContentOnly   bool
+	FullSite      bool
+	AllTagWeights bool
 	TagWeights
 	ExtraTagWeights TagWeights
 	AdjustScores    bool

--- a/config/options.go
+++ b/config/options.go
@@ -126,6 +126,13 @@ var (
 		}
 	}
 
+	// AllTagWeights ...
+	AllTagWeights = func(v bool) Option {
+		return func(c *Config) {
+			c.AllTagWeights = v
+		}
+	}
+
 	AdjustScores = func(v bool) Option {
 		return func(c *Config) {
 			c.AdjustScores = v

--- a/config/options.go
+++ b/config/options.go
@@ -126,6 +126,13 @@ var (
 		}
 	}
 
+	// ExcludeTagsString ...
+	ExcludeTagsString = func(v string) Option {
+		return func(c *Config) {
+			c.ExcludeTags = ParseTagWeights(strings.NewReader(v), String)
+		}
+	}
+
 	// AllTagWeights ...
 	AllTagWeights = func(v bool) Option {
 		return func(c *Config) {

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -11,6 +11,28 @@ type Extension interface {
 	Result() *Result
 }
 
+type BaseExtension struct {
+	name    string
+	version string
+	result  *Result
+}
+
+func NewExtension(name, version string) *BaseExtension {
+	return &BaseExtension{name: name, version: version}
+}
+
+func (ext *BaseExtension) Name() string {
+	return ext.name
+}
+
+func (ext *BaseExtension) Version() string {
+	return ext.version
+}
+
+func (ext *BaseExtension) Result() string {
+	return ext.Result()
+}
+
 // ExtResult ...
 type Result struct {
 	Name    string                 `json:"name"`

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -8,13 +8,13 @@ package extension
 type Extension interface {
 	Name() string
 	Version() string
-	Result() *Result
+	Result() *ExtResult
 }
 
 type BaseExtension struct {
 	name    string
 	version string
-	result  *Result
+	*ExtResult
 }
 
 func NewExtension(name, version string) *BaseExtension {
@@ -29,12 +29,12 @@ func (ext *BaseExtension) Version() string {
 	return ext.version
 }
 
-func (ext *BaseExtension) Result() string {
-	return ext.Result()
+func (ext *BaseExtension) Result() *ExtResult {
+	return ext.ExtResult
 }
 
 // ExtResult ...
-type Result struct {
+type ExtResult struct {
 	Name    string                 `json:"name"`
 	Version string                 `json:"version"`
 	Err     error                  `json:"error,omitempty"`
@@ -42,8 +42,8 @@ type Result struct {
 }
 
 // NewResult ...
-func NewResult(ext Extension, data map[string]interface{}, err error) *Result {
-	return &Result{
+func NewResult(ext Extension, data map[string]interface{}, err error) *ExtResult {
+	return &ExtResult{
 		Name:    ext.Name(),
 		Version: ext.Version(),
 		Err:     err,
@@ -52,12 +52,12 @@ func NewResult(ext Extension, data map[string]interface{}, err error) *Result {
 }
 
 // MapResults ...
-func MapResults(exts []Extension) map[string]map[string]*Result {
-	res := map[string]map[string]*Result{}
+func MapResults(exts []Extension) map[string]map[string]*ExtResult {
+	res := map[string]map[string]*ExtResult{}
 	for _, v := range exts {
 		e, ok := res[v.Name()]
 		if !ok {
-			e = map[string]*Result{}
+			e = map[string]*ExtResult{}
 			res[v.Name()] = e
 		}
 		e[v.Version()] = v.Result()

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.17
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -43,15 +43,10 @@ github.com/zoomio/stopwords v0.10.0 h1:HD2Sg+nC4aSPuKBth7Ll6M6nnCg6Epfl+KzTnOhEC
 github.com/zoomio/stopwords v0.10.0/go.mod h1:o4QuYCodF27JOxswxYtH5nD9DNXYRV4rrbMEoH3/zhQ=
 golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d h1:62NvYBuaanGXR2ZOfwDFkhhl6X1DUgf8qg3GuQvxZsE=
 golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210818153620-00dd8d7831e7 h1:/bmDWM82ZX7TawqxuI8kVjKI0TXHdSY6pHJArewwHtU=
 golang.org/x/sys v0.0.0-20210818153620-00dd8d7831e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/model.go
+++ b/model.go
@@ -24,6 +24,7 @@ var (
 	TagWeightsJSON        = config.TagWeightsJSON
 	ExtraTagWeightsString = config.ExtraTagWeightsString
 	ExtraTagWeightsJSON   = config.ExtraTagWeightsJSON
+	ExcludeTagsString     = config.ExcludeTagsString
 	AllTagWeights         = config.AllTagWeights
 	AdjustScores          = config.AdjustScores
 	Extensions            = config.Extensions

--- a/model.go
+++ b/model.go
@@ -24,6 +24,7 @@ var (
 	TagWeightsJSON        = config.TagWeightsJSON
 	ExtraTagWeightsString = config.ExtraTagWeightsString
 	ExtraTagWeightsJSON   = config.ExtraTagWeightsJSON
+	AllTagWeights         = config.AllTagWeights
 	AdjustScores          = config.AdjustScores
 	Extensions            = config.Extensions
 

--- a/model/model.go
+++ b/model/model.go
@@ -105,9 +105,9 @@ func (r *Result) TagsStrings() []string {
 	return ToStrings(r.Tags)
 }
 
-// ParseFunc represents an arbitrary handler,
+// ProcessFunc represents an arbitrary handler,
 // which goes through given reader and produces tags.
-type ParseFunc func(c *config.Config, reader io.ReadCloser) *Result
+type ProcessFunc func(c *config.Config, reader io.ReadCloser) *Result
 
 func flatten(dict map[string]*Tag) []*Tag {
 	flat := make([]*Tag, len(dict))

--- a/model/model.go
+++ b/model/model.go
@@ -54,7 +54,7 @@ type Result struct {
 	Meta       *Meta
 	RawTags    map[string]*Tag
 	Tags       []*Tag // processed slice of the result dictionary - RawTags
-	Extensions map[string]map[string]*extension.Result
+	Extensions map[string]map[string]*extension.ExtResult
 	Err        error
 }
 
@@ -64,12 +64,12 @@ func (res *Result) Flatten() []*Tag {
 }
 
 // FindExtResults finds requested extension result(s), in case if version is empty.
-func (res *Result) FindExtResults(name, version string) []*extension.Result {
+func (res *Result) FindExtResults(name, version string) []*extension.ExtResult {
 	vs, ok := res.Extensions[name]
 	if !ok {
 		return nil
 	}
-	list := []*extension.Result{}
+	list := []*extension.ExtResult{}
 	if version != "" {
 		if v, ok := vs[version]; ok {
 			list = append(list, v)

--- a/processor/html/extension_test.go
+++ b/processor/html/extension_test.go
@@ -101,7 +101,7 @@ func (ext *testImgCrawlerExt) Version() string {
 	return "v0.0.1"
 }
 
-func (ext *testImgCrawlerExt) Result() *extension.Result {
+func (ext *testImgCrawlerExt) Result() *extension.ExtResult {
 	return extension.NewResult(ext, map[string]interface{}{"images": ext.images}, nil)
 }
 
@@ -128,7 +128,7 @@ func (ext *testExtraStopWordsExt) Version() string {
 	return "v0.0.1"
 }
 
-func (ext *testExtraStopWordsExt) Result() *extension.Result {
+func (ext *testExtraStopWordsExt) Result() *extension.ExtResult {
 	return extension.NewResult(ext, map[string]interface{}{"stopwords": ext.stopWords}, nil)
 }
 
@@ -150,7 +150,7 @@ func (ext *testStopExt) Version() string {
 	return "v0.0.1"
 }
 
-func (ext *testStopExt) Result() *extension.Result {
+func (ext *testStopExt) Result() *extension.ExtResult {
 	return extension.NewResult(ext, map[string]interface{}{}, nil)
 }
 

--- a/processor/html/extension_test.go
+++ b/processor/html/extension_test.go
@@ -32,7 +32,7 @@ func Test_Ext_Parse_img(t *testing.T) {
 		config.TagWeightsString("h2:1|img:0"),
 		config.Extensions([]extension.Extension{newTestImgCrawlerExt()}),
 	)
-	out := ParseHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
+	out := ProcessHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
 	assert.Len(t, out.Extensions, 1)
 	results := out.FindExtResults("test-img-crawler", "v0.0.1") //Extensions["test-img-crawler"]
 	assert.Len(t, results, 1)
@@ -49,10 +49,10 @@ func Test_Ext_Parse_img(t *testing.T) {
 
 func Test_Ext_Tagify_stopwords(t *testing.T) {
 	cfg1 := config.New()
-	out1 := ParseHTML(cfg1, &inputReadCloser{strings.NewReader(htmlWithImg)})
+	out1 := ProcessHTML(cfg1, &inputReadCloser{strings.NewReader(htmlWithImg)})
 
 	cfg2 := config.New(config.Extensions([]extension.Extension{&testExtraStopWordsExt{stopWords: []string{"day", "sunset"}}}))
-	out2 := ParseHTML(cfg2, &inputReadCloser{strings.NewReader(htmlWithImg)})
+	out2 := ProcessHTML(cfg2, &inputReadCloser{strings.NewReader(htmlWithImg)})
 
 	assert.Len(t, out1.Extensions, 0)
 	assert.Len(t, out2.Extensions, 1)
@@ -70,7 +70,7 @@ func Test_Ext_ParseEnd(t *testing.T) {
 		config.ExtraTagWeightsString("img:0"),
 		config.NoStopWords(true),
 	)
-	out := ParseHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
+	out := ProcessHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
 	assert.Equal(t, 7, out.RawLen())
 
 	// Amount of tags when stopped is 3 (see assert.Len)
@@ -79,7 +79,7 @@ func Test_Ext_ParseEnd(t *testing.T) {
 		config.Extensions([]extension.Extension{&testStopExt{}}),
 		config.NoStopWords(true),
 	)
-	out = ParseHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
+	out = ProcessHTML(cfg, &inputReadCloser{strings.NewReader(htmlWithImg)})
 	assert.Equal(t, 3, out.RawLen())
 }
 

--- a/processor/html/html_processor.go
+++ b/processor/html/html_processor.go
@@ -129,9 +129,9 @@ var ProcessHTML model.ProcessFunc = func(c *config.Config, reader io.ReadCloser)
 		}
 	}
 
-	if c.Verbose {
-		fmt.Printf("using configuration: %#v\n", c)
-	}
+	// if c.Verbose {
+	// 	fmt.Printf("using configuration: %#v\n", c)
+	// }
 
 	if c.FullSite && c.Source != "" {
 		var crawler *webCrawler

--- a/processor/html/html_processor.go
+++ b/processor/html/html_processor.go
@@ -86,8 +86,8 @@ func isSameDomain(href, domain string) bool {
 	return strings.HasSuffix(dest[:i], host)
 }
 
-func updateDetectStr(candidate, controlStr string) string {
-	if len(candidate) > len(controlStr) {
+func updateDetectStr(cursor, candidate, controlStr string) string {
+	if isHTMLContent(cursor) && len(candidate) > len(controlStr) {
 		return candidate
 	}
 	return controlStr
@@ -250,7 +250,7 @@ func ParseHTML(reader io.Reader, cfg *config.Config, exts []HTMLExt, c *webCrawl
 					}
 				}
 				if name == "description" {
-					controlStr = updateDetectStr(content, controlStr)
+					controlStr = updateDetectStr(cursor, content, controlStr)
 					contents.Append(parser.lineIndex, cursor, []byte(content))
 					appended = true
 				}
@@ -333,7 +333,7 @@ func ParseHTML(reader io.Reader, cfg *config.Config, exts []HTMLExt, c *webCrawl
 					}
 				}
 
-				controlStr = updateDetectStr(token.Data, controlStr)
+				controlStr = updateDetectStr(cursor, token.Data, controlStr)
 				contents.Append(parser.lineIndex, cursor, []byte(token.Data))
 			}
 		}

--- a/processor/html/html_processor_test.go
+++ b/processor/html/html_processor_test.go
@@ -380,10 +380,6 @@ type testCountingExt struct {
 	count int
 }
 
-func (ext *testCountingExt) Result() *extension.Result {
-	return extension.NewResult(ext, map[string]interface{}{"count": ext.count}, nil)
-}
-
 func (ext *testCountingExt) ParseTag(cfg *config.Config, token *html.Token, lineIdx int, cnts *HTMLContents) (bool, error) {
 	ext.count++
 	return false, nil

--- a/processor/html/html_processor_test.go
+++ b/processor/html/html_processor_test.go
@@ -307,7 +307,7 @@ func Test_ParseHTML(t *testing.T) {
 	for _, tt := range parseHTMLTests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := config.New(config.NoStopWords(tt.noStopWords), config.ContentOnly(tt.contentOnly))
-			out := ParseHTML(c, &inputReadCloser{strings.NewReader(tt.in)})
+			out := ProcessHTML(c, &inputReadCloser{strings.NewReader(tt.in)})
 			assert.Equal(t, tt.title, out.Meta.DocTitle)
 			assert.Equal(t, tt.hash, out.Meta.DocHash)
 			assert.ElementsMatch(t, tt.expect, model.ToStrings(out.Flatten()))
@@ -316,7 +316,7 @@ func Test_ParseHTML(t *testing.T) {
 }
 
 func Test_ParseHTML_DedupeTitleAndHeading(t *testing.T) {
-	out := ParseHTML(config.New(config.NoStopWords(true)), &inputReadCloser{strings.NewReader(htmlDupedString)})
+	out := ProcessHTML(config.New(config.NoStopWords(true)), &inputReadCloser{strings.NewReader(htmlDupedString)})
 	assert.Equal(t, "A story about a boy", out.Meta.DocTitle)
 	assert.Equal(t,
 		"4f652c47205d3b922115eef155c484cf81096351696413c86277fa0ed89ebfefe30f81ef6fc6a9d7d654a9292c3cb7aa6f3696052e53c113785a9b1b3be7d4a8",
@@ -325,7 +325,7 @@ func Test_ParseHTML_DedupeTitleAndHeading(t *testing.T) {
 }
 
 func Test_ParseHTML_NoSpecificStopWords(t *testing.T) {
-	out := ParseHTML(config.New(config.NoStopWords(true)), &inputReadCloser{strings.NewReader(htmlDupedString)})
+	out := ProcessHTML(config.New(config.NoStopWords(true)), &inputReadCloser{strings.NewReader(htmlDupedString)})
 	assert.Equal(t, "A story about a boy", out.Meta.DocTitle)
 	assert.Equal(t,
 		"4f652c47205d3b922115eef155c484cf81096351696413c86277fa0ed89ebfefe30f81ef6fc6a9d7d654a9292c3cb7aa6f3696052e53c113785a9b1b3be7d4a8",
@@ -341,7 +341,7 @@ func Test_parseHTML(t *testing.T) {
 	</body>
 	</html>
 `
-	contents := parseHTML(
+	contents := ParseHTML(
 		&inputReadCloser{strings.NewReader(htmlPage)},
 		&config.Config{TagWeights: defaultTagWeights},
 		nil,

--- a/processor/html/html_processor_test.go
+++ b/processor/html/html_processor_test.go
@@ -368,7 +368,12 @@ func Test_ParseHTML(t *testing.T) {
 
 func Test_ParseReaderHTML_visits_all_tags(t *testing.T) {
 	counter := &testCountingExt{BaseExtension: extension.NewExtension("testCountingExt", "1")}
-	contents := ParseReaderHTML(io.NopCloser(strings.NewReader(theVergeHTMLWithMetaDescription)), []HTMLExt{counter})
+	contents := ParseHTML(
+		io.NopCloser(strings.NewReader(theVergeHTMLWithMetaDescription)),
+		&config.Config{Verbose: false, SkipLang: true, AllTagWeights: true},
+		[]HTMLExt{counter},
+		nil,
+	)
 
 	assert.NotNil(t, contents)
 	assert.Len(t, contents.lines, 1)

--- a/processor/html/html_processor_test.go
+++ b/processor/html/html_processor_test.go
@@ -367,7 +367,7 @@ func Test_ParseHTML(t *testing.T) {
 }
 
 func Test_ParseReaderHTML_visits_all_tags(t *testing.T) {
-	counter := &testCountingExt{}
+	counter := &testCountingExt{BaseExtension: extension.NewExtension("testCountingExt", "1")}
 	contents := ParseReaderHTML(io.NopCloser(strings.NewReader(theVergeHTMLWithMetaDescription)), []HTMLExt{counter})
 
 	assert.NotNil(t, contents)
@@ -376,15 +376,8 @@ func Test_ParseReaderHTML_visits_all_tags(t *testing.T) {
 }
 
 type testCountingExt struct {
+	*extension.BaseExtension
 	count int
-}
-
-func (ext *testCountingExt) Name() string {
-	return "test-counter"
-}
-
-func (ext *testCountingExt) Version() string {
-	return "v0.0.1"
 }
 
 func (ext *testCountingExt) Result() *extension.Result {

--- a/processor/md/md_processor.go
+++ b/processor/md/md_processor.go
@@ -101,15 +101,15 @@ func (t mdType) String() string {
 	return mdTypes[t]
 }
 
-// ParseMD parses given Markdown document input into a slice of tags.
-var ParseMD model.ParseFunc = func(c *config.Config, in io.ReadCloser) *model.Result {
+// ProcessMD parses given Markdown document input into a slice of tags.
+var ProcessMD model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *model.Result {
 
 	if c.Verbose {
 		fmt.Println("--> parsing Markdown...")
 	}
 
 	defer in.Close()
-	contents := parseMD(in)
+	contents := ParseMD(in)
 
 	if c.Verbose {
 		fmt.Println("--> parsed")
@@ -138,9 +138,9 @@ var ParseMD model.ParseFunc = func(c *config.Config, in io.ReadCloser) *model.Re
 	}
 }
 
-func parseMD(reader io.Reader) *mdContents {
+func ParseMD(reader io.Reader) *MDContents {
 
-	contents := &mdContents{lines: make([]*mdLine, 0)}
+	contents := &MDContents{lines: make([]*mdLine, 0)}
 	scanner := bufio.NewScanner(reader)
 
 	index := -1
@@ -208,7 +208,7 @@ func parseMD(reader io.Reader) *mdContents {
 	return contents
 }
 
-func tagifyMD(contents *mdContents, c *config.Config) (tokenIndex map[string]*model.Tag, pageTitle string, lang string) {
+func tagifyMD(contents *MDContents, c *config.Config) (tokenIndex map[string]*model.Tag, pageTitle string, lang string) {
 	tokenIndex = make(map[string]*model.Tag)
 	var docsCount int
 	var reg *stopwords.Register
@@ -291,7 +291,7 @@ func isMDHeading(t mdType) bool {
 	}
 }
 
-func appendLine(lineIndex int, line []byte, handlers map[int]*mdPartHandler, cnt *mdContents) {
+func appendLine(lineIndex int, line []byte, handlers map[int]*mdPartHandler, cnt *MDContents) {
 	i := 0
 	p := []byte{}
 	for i < len(line) {
@@ -329,12 +329,12 @@ type mdPartHandler struct {
 	re    *regexp.Regexp
 }
 
-// mdContents stores text from target tags.
-type mdContents struct {
+// MDContents stores text from target tags.
+type MDContents struct {
 	lines []*mdLine
 }
 
-func (cnt *mdContents) append(index int, tag mdType, data []byte) {
+func (cnt *MDContents) append(index int, tag mdType, data []byte) {
 	for len(cnt.lines) <= index {
 		cnt.lines = append(cnt.lines, &mdLine{tag: tag, parts: make([]*mdPart, 0)})
 	}
@@ -342,13 +342,13 @@ func (cnt *mdContents) append(index int, tag mdType, data []byte) {
 	line.add(tag, data)
 }
 
-func (cnt *mdContents) forEach(it func(i int, line *mdLine)) {
+func (cnt *MDContents) forEach(it func(i int, line *mdLine)) {
 	for k, v := range cnt.lines {
 		it(k, v)
 	}
 }
 
-func (cnt *mdContents) String() string {
+func (cnt *MDContents) String() string {
 	var sb strings.Builder
 	cnt.forEach(func(i int, line *mdLine) {
 		sb.WriteString(fmt.Sprintf("[%d] ", i))
@@ -358,7 +358,7 @@ func (cnt *mdContents) String() string {
 	return sb.String()
 }
 
-func (cnt *mdContents) hash() []byte {
+func (cnt *MDContents) hash() []byte {
 	h := sha512.New()
 	cnt.forEach(func(i int, line *mdLine) {
 		_, _ = h.Write([]byte(line.tag.String()))

--- a/processor/md/md_processor.go
+++ b/processor/md/md_processor.go
@@ -125,9 +125,9 @@ var ProcessMD model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *mode
 		}
 	}
 
-	if c.Verbose {
-		fmt.Printf("using configuration: %#v\n", c)
-	}
+	// if c.Verbose {
+	// 	fmt.Printf("using configuration: %#v\n", c)
+	// }
 
 	tags, title, lang := tagifyMD(contents, c)
 

--- a/processor/md/md_processor.go
+++ b/processor/md/md_processor.go
@@ -125,6 +125,10 @@ var ProcessMD model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *mode
 		}
 	}
 
+	if c.Verbose {
+		fmt.Printf("using configuration: %#v\n", c)
+	}
+
 	tags, title, lang := tagifyMD(contents, c)
 
 	return &model.Result{

--- a/processor/md/md_processor_test.go
+++ b/processor/md/md_processor_test.go
@@ -84,7 +84,7 @@ var parseMDTests = []struct {
 func Test_ParseMD(t *testing.T) {
 	for _, tt := range parseMDTests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := ParseMD(config.New(config.NoStopWords(tt.noStopWords)), &inputReadCloser{strings.NewReader(tt.text)})
+			out := ProcessMD(config.New(config.NoStopWords(tt.noStopWords)), &inputReadCloser{strings.NewReader(tt.text)})
 			assert.Equal(t, tt.title, out.Meta.DocTitle)
 			assert.Equal(t, tt.hash, out.Meta.DocHash)
 			assert.ElementsMatch(t, tt.tags, model.ToStrings(out.Flatten()))
@@ -93,7 +93,7 @@ func Test_ParseMD(t *testing.T) {
 }
 
 func Test_mdContents_sentences(t *testing.T) {
-	contents := &mdContents{
+	contents := &MDContents{
 		lines: []*mdLine{
 			{tag: paragraph, data: []byte("There was a boy"), parts: []*mdPart{{tag: paragraph, pos: 0, len: 18}}},
 			{tag: paragraph, data: []byte("Whose name was Jim.	"), parts: []*mdPart{{tag: paragraph, pos: 0, len: 21}}},

--- a/processor/text/text_processor.go
+++ b/processor/text/text_processor.go
@@ -15,8 +15,8 @@ import (
 	"github.com/zoomio/tagify/processor/util"
 )
 
-// ParseText parses given text lines of text into a slice of tags.
-var ParseText model.ParseFunc = func(c *config.Config, in io.ReadCloser) *model.Result {
+// ProcessText parses given text lines of text into a slice of tags.
+var ProcessText model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *model.Result {
 
 	if c.Verbose {
 		fmt.Println("parsing plain text...")

--- a/processor/text/text_processor.go
+++ b/processor/text/text_processor.go
@@ -22,9 +22,9 @@ var ProcessText model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *mo
 		fmt.Println("parsing plain text...")
 	}
 
-	if c.Verbose {
-		fmt.Printf("using configuration: %#v\n", c)
-	}
+	// if c.Verbose {
+	// 	fmt.Printf("using configuration: %#v\n", c)
+	// }
 
 	var docsCount int
 

--- a/processor/text/text_processor.go
+++ b/processor/text/text_processor.go
@@ -22,6 +22,10 @@ var ProcessText model.ProcessFunc = func(c *config.Config, in io.ReadCloser) *mo
 		fmt.Println("parsing plain text...")
 	}
 
+	if c.Verbose {
+		fmt.Printf("using configuration: %#v\n", c)
+	}
+
 	var docsCount int
 
 	defer in.Close()

--- a/processor/text/text_processor_test.go
+++ b/processor/text/text_processor_test.go
@@ -22,30 +22,30 @@ var (
 )
 
 func Test_ParseText_Empty(t *testing.T) {
-	out := ParseText(config.New(), inout.NewFromString(""))
+	out := ProcessText(config.New(), inout.NewFromString(""))
 	assert.Len(t, out.RawTags, 0)
 }
 
 func Test_ParseText_WithStopWords(t *testing.T) {
-	out := ParseText(config.New(), inout.NewFromString(text))
+	out := ProcessText(config.New(), inout.NewFromString(text))
 	assert.Len(t, out.RawTags, 7)
 	assert.Subset(t, model.ToStrings(out.Flatten()), []string{"there", "was", "a", "boy", "who's", "name", "jim"})
 }
 
 func Test_ParseText_NoStopWords(t *testing.T) {
-	out := ParseText(config.New(config.NoStopWords(true)), inout.NewFromString(text))
+	out := ProcessText(config.New(config.NoStopWords(true)), inout.NewFromString(text))
 	assert.Len(t, out.RawTags, 2)
 	assert.Subset(t, model.ToStrings(out.Flatten()), []string{"boy", "jim"})
 }
 
 func Test_calculatesVersion(t *testing.T) {
-	out1 := ParseText(config.New(), inout.NewFromString(text))
+	out1 := ProcessText(config.New(), inout.NewFromString(text))
 	assert.Nil(t, out1.Err)
 	assert.Equal(t,
 		"323c7bf1fe804151d8c378648061d861554a4ae5d02558ce140c1ee3ff186c37a1600bab87abada56d50148b35c121c8b1abb5db8c13a75e9d676fd9130f3c6a",
 		out1.Meta.DocHash)
 
-	out2 := ParseText(config.New(), inout.NewFromString(text2))
+	out2 := ProcessText(config.New(), inout.NewFromString(text2))
 	assert.Nil(t, out2.Err)
 	assert.Equal(t,
 		"2f1ba6d722f14042db22ea7c433d02c8b666b33106b1c18bac00388b0ee3add19f411b234981293864698fc9e9dc9073b966378bcb6f49b1c7f07ca99a17a5cc",

--- a/tagify.go
+++ b/tagify.go
@@ -48,18 +48,13 @@ func Run(ctx context.Context, options ...Option) (*model.Result, error) {
 	return res, nil
 }
 
-// ToStrings transforms a list of tags into a list of strings.
-func ToStrings(items []*model.Tag) []string {
-	return model.ToStrings(items)
-}
-
 func processInput(in *in, c *Config) *model.Result {
 	switch in.ContentType {
 	case HTML:
-		return html.ParseHTML(c, in)
+		return html.ProcessHTML(c, in)
 	case Markdown:
-		return md.ParseMD(c, in)
+		return md.ProcessMD(c, in)
 	default:
-		return text.ParseText(c, in)
+		return text.ProcessText(c, in)
 	}
 }

--- a/tagify_test.go
+++ b/tagify_test.go
@@ -91,7 +91,7 @@ func Test_ToStrings(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	strs := ToStrings(res.Tags)
+	strs := model.ToStrings(res.Tags)
 	assert.Len(t, strs, 3)
 }
 

--- a/tagify_test.go
+++ b/tagify_test.go
@@ -203,7 +203,7 @@ func (ext *customHTML) Version() string {
 	return "v0.0.1"
 }
 
-func (ext *customHTML) Result() *extension.Result {
+func (ext *customHTML) Result() *extension.ExtResult {
 	return extension.NewResult(ext, map[string]interface{}{"text": ext.text}, nil)
 }
 


### PR DESCRIPTION
…`, `ParseMD` & `ParseText` to `ProcessHTML`, `ProcessMD` & `ProcessText` respectively; Made public `ParseHTML` & `ParseMD` just for the parsing purposes.