### PR TITLE
Using short language code

### DIFF
--- a/config/language.go
+++ b/config/language.go
@@ -21,7 +21,7 @@ func DetectLang(cfg *Config, controlStr string, contents Vocabulary) {
 				controlStr, info.Lang.String(), info.Lang.Iso6391(), info.Lang.Iso6393(), info.Confidence)
 		}
 		if info.IsReliable() {
-			contents.SetLang(info.Lang.String())
+			contents.SetLang(info.Lang.Iso6391())
 			cfg.SetStopWords(info.Lang.Iso6391())
 		} else {
 			contents.SetLang("English")


### PR DESCRIPTION
`info.Lang.String` got `Mandarin` instead of `zh`, change `info.Lang.String` to `info.Lang.Iso6391` fix Mandarin text segment

Ref: https://github.com/abadojack/whatlanggo/blob/9a096a12270b527608792719d6e75e68a8bbfb03/lang.go#L191-L212